### PR TITLE
feature: Add optional params "uppReturnMaskedCC" and "useAlias" to obtain additional data from purchase request

### DIFF
--- a/src/Message/AbstractRedirectRequest.php
+++ b/src/Message/AbstractRedirectRequest.php
@@ -22,8 +22,7 @@ abstract class AbstractRedirectRequest extends AbstractRequest
      * @var array
      */
     protected $optionalParams = array(
-        'uppReturnMaskedCC',
-        'useAlias',
+
     );
 
     /**
@@ -38,13 +37,13 @@ abstract class AbstractRedirectRequest extends AbstractRequest
             'refno'      => $this->getTransactionId(),
             'amount'     => $this->getAmountInteger(),
             'currency'   => $this->getCurrency(),
-            'sign'       => $this->getSign(),
+            'sign'       => $this->getSign()
         );
 
         foreach ($this->optionalParams as $param) {
             $value = $this->getParameter($param);
 
-            if (!empty($value)) {
+            if ($value !== '') {
                 $data[$param] = $value;
             }
         }
@@ -91,23 +90,5 @@ abstract class AbstractRedirectRequest extends AbstractRequest
     public function sendData($data)
     {
         return $this->response = new PurchaseResponse($this, $data);
-    }
-
-    /**
-     * @param $value
-     * @return \Omnipay\Common\Message\AbstractRequest
-     */
-    public function setUppReturnMaskedCC($value)
-    {
-        return $this->setParameter('uppReturnMaskedCC', $value);
-    }
-
-    /**
-     * @param $value
-     * @return \Omnipay\Common\Message\AbstractRequest
-     */
-    public function setUseAlias($value)
-    {
-        return $this->setParameter('useAlias', $value);
     }
 }

--- a/src/Message/AbstractRedirectRequest.php
+++ b/src/Message/AbstractRedirectRequest.php
@@ -23,7 +23,7 @@ abstract class AbstractRedirectRequest extends AbstractRequest
      */
     protected $optionalParams = array(
         'uppReturnMaskedCC',
-        'useAlias'
+        'useAlias',
     );
 
     /**
@@ -38,7 +38,7 @@ abstract class AbstractRedirectRequest extends AbstractRequest
             'refno'      => $this->getTransactionId(),
             'amount'     => $this->getAmountInteger(),
             'currency'   => $this->getCurrency(),
-            'sign'       => $this->getSign()
+            'sign'       => $this->getSign(),
         );
 
         foreach ($this->optionalParams as $param) {
@@ -106,7 +106,8 @@ abstract class AbstractRedirectRequest extends AbstractRequest
      * @param $value
      * @return \Omnipay\Common\Message\AbstractRequest
      */
-    public function setUseAlias($value){
+    public function setUseAlias($value)
+    {
         return $this->setParameter('useAlias', $value);
     }
 }

--- a/src/Message/AbstractRedirectRequest.php
+++ b/src/Message/AbstractRedirectRequest.php
@@ -22,7 +22,8 @@ abstract class AbstractRedirectRequest extends AbstractRequest
      * @var array
      */
     protected $optionalParams = array(
-
+        'uppReturnMaskedCC',
+        'useAlias'
     );
 
     /**
@@ -43,7 +44,7 @@ abstract class AbstractRedirectRequest extends AbstractRequest
         foreach ($this->optionalParams as $param) {
             $value = $this->getParameter($param);
 
-            if ($value !== '') {
+            if (!empty($value)) {
                 $data[$param] = $value;
             }
         }
@@ -90,5 +91,22 @@ abstract class AbstractRedirectRequest extends AbstractRequest
     public function sendData($data)
     {
         return $this->response = new PurchaseResponse($this, $data);
+    }
+
+    /**
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setUppReturnMaskedCC($value)
+    {
+        return $this->setParameter('uppReturnMaskedCC', $value);
+    }
+
+    /**
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setUseAlias($value){
+        return $this->setParameter('useAlias', $value);
     }
 }

--- a/src/Message/AbstractResponse.php
+++ b/src/Message/AbstractResponse.php
@@ -25,12 +25,12 @@ abstract class AbstractResponse extends OmnipayAbstractResponse implements Redir
     /**
      * @var string
      */
-    protected $productionEndpoint = 'https://payment.datatrans.biz/upp/jsp/upStart.jsp';
+    protected $productionEndpoint = 'https://pay.datatrans.com/upp/jsp/upStart.jsp';
 
     /**
      * @var string
      */
-    protected $testEndpoint = 'https://pay.datatrans.com/upp/jsp/upStart.jsp';
+    protected $testEndpoint = 'https://pay.sandbox.datatrans.com/upp/jsp/upStart.jsp';
 
     /*** STATUS CODES ****/
     /**

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -16,5 +16,56 @@ namespace Omnipay\Datatrans\Message;
 
 class PurchaseRequest extends AbstractRedirectRequest
 {
+    /**
+     * @var array
+     */
+    protected $optionalParams = array(
+        'useAlias',
+        'uppReturnMaskedCC'
+    );
 
+    /**
+     * @return array
+     */
+    public function getData()
+    {
+        $data = parent::getData();
+
+        //set customer details if set
+        if (($customerDetails = $this->getParameter('uppCustomerDetails')) && is_array($customerDetails)){
+            $data['uppCustomerDetails'] = 'yes';
+            foreach ($customerDetails as $key => $value){
+                $data[$key] = $value;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+      * @param $value
+      * @return \Omnipay\Common\Message\AbstractRequest
+      */
+    public function setUppReturnMaskedCC($value)
+    {
+        return $this->setParameter('uppReturnMaskedCC', $value);
+    }
+
+    /**
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setUseAlias($value)
+    {
+        return $this->setParameter('useAlias', $value);
+    }
+
+    /**
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setUppCustomerDetails($value)
+    {
+        return $this->setParameter('uppCustomerDetails', $value);
+    }
 }

--- a/src/Message/XmlAuthorizationRequest.php
+++ b/src/Message/XmlAuthorizationRequest.php
@@ -26,7 +26,8 @@ class XmlAuthorizationRequest extends XmlRequest
      */
     protected $optionalParameters = array(
         'reqtype',
-        'uppCustomerIpAddress'
+        'uppCustomerIpAddress',
+        'useAlias'
     );
 
     /**
@@ -57,7 +58,7 @@ class XmlAuthorizationRequest extends XmlRequest
             'aliasCC'    => $this->getCard()->getNumber(),
             'expm'       => $this->getCard()->getExpiryMonth(),
             'expy'       => $this->getCard()->getExpiryDate('y'),
-            'useAlias' => 'no'
+            'useAlias'   => 'no'
         );
 
         foreach ($this->optionalParameters as $param) {
@@ -78,5 +79,14 @@ class XmlAuthorizationRequest extends XmlRequest
     protected function createResponse($data)
     {
         return $this->response = new XmlAuthorizationResponse($this, $data);
+    }
+
+    /**
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setUseAlias($value)
+    {
+        return $this->setParameter('useAlias', $value);
     }
 }

--- a/src/Message/XmlRequest.php
+++ b/src/Message/XmlRequest.php
@@ -27,13 +27,13 @@ abstract class XmlRequest extends AbstractRequest
      *
      * @var string
      */
-    protected $apiBaseProdUrl = 'https://api.sandbox.datatrans.com/upp/jsp';
+    protected $apiBaseProdUrl = 'https://api.datatrans.com/upp/jsp';
     /**
      * The XML API Endpoint Base URL
      *
      * @var string
      */
-    protected $apiBaseTestUrl = 'https://pay.sandbox.datatrans.com/upp/jsp';
+    protected $apiBaseTestUrl = 'https://api.sandbox.datatrans.com/upp/jsp';
 
     /**
      * defines the endpoint for a specific api

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -51,7 +51,7 @@ class GatewayTest extends GatewayTestCase
         $this->assertTrue($response->isRedirect());
         $this->assertEquals('POST', $response->getRedirectMethod());
         $this->assertEquals($data, $response->getRedirectData());
-        $this->assertStringStartsWith('https://pay.datatrans.com/upp/jsp/upStart.jsp', $response->getRedirectUrl());
+        $this->assertStringStartsWith('https://pay.sandbox.datatrans.com/upp/jsp/upStart.jsp', $response->getRedirectUrl());
     }
 
     public function testCompletePurchaseSuccess()

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -30,7 +30,9 @@ class PurchaseRequestTest extends TestCase
             'transactionId' => '123',
             'returnUrl' => 'https://www.example.com/success',
             'errorUrl' => 'https://www.example.com/error',
-            'cancelUrl' => 'https://www.example.com/cancel'
+            'cancelUrl' => 'https://www.example.com/cancel',
+            'uppReturnMaskedCC' => 'yes',
+            'useAlias' => ''
         ));
 
         $expected = array(
@@ -41,7 +43,8 @@ class PurchaseRequestTest extends TestCase
             'sign' => '123',
             'successUrl' => 'https://www.example.com/success',
             'errorUrl' => 'https://www.example.com/error',
-            'cancelUrl' => 'https://www.example.com/cancel'
+            'cancelUrl' => 'https://www.example.com/cancel',
+            'uppReturnMaskedCC' => 'yes'
         );
 
         $this->assertEquals($expected, $this->request->getData());

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -30,7 +30,9 @@ class PurchaseRequestTest extends TestCase
             'transactionId' => '123',
             'returnUrl' => 'https://www.example.com/success',
             'errorUrl' => 'https://www.example.com/error',
-            'cancelUrl' => 'https://www.example.com/cancel'
+            'cancelUrl' => 'https://www.example.com/cancel',
+            'uppReturnMaskedCC' => 'yes',
+            'useAlias' => 'yes'
         ));
 
         $expected = array(
@@ -41,7 +43,9 @@ class PurchaseRequestTest extends TestCase
             'sign' => '123',
             'successUrl' => 'https://www.example.com/success',
             'errorUrl' => 'https://www.example.com/error',
-            'cancelUrl' => 'https://www.example.com/cancel'
+            'cancelUrl' => 'https://www.example.com/cancel',
+            'uppReturnMaskedCC' => 'yes',
+            'useAlias' => 'yes'
         );
 
         $this->assertEquals($expected, $this->request->getData());


### PR DESCRIPTION
Hi there

Me again 😀  I just need to request some additional data to implement Token billing.

Atm i am working on a Symfony 3 Bundle to use Datatrans in JMSPaymentCoreBundle. Sooo perhaps i will create some more pull requests in the future. 

Cheers